### PR TITLE
Require a newer version of `UserNSSandbox_jll`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ UserNSSandbox_jll = "b88861f7-1d72-59dd-91e7-a8cc876a4984"
 JLLWrappers = "1.2"
 Scratch = "1"
 julia = "1.6"
+UserNSSandbox_jll = "2021.1.19"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
We require a version of `UserNSSandbox_jll` that has the `--entrypoint` capability.