### PR TITLE
Allow the `with_executor` function to take keyword arguments, which it will forward to the `executor_type` constructor

### DIFF
--- a/src/Sandbox.jl
+++ b/src/Sandbox.jl
@@ -114,8 +114,12 @@ for f in (:run, :success)
     end
 end
 
-function with_executor(f::Function, executor_type::Type{<:SandboxExecutor} = preferred_executor())
-    exe = executor_type()
+"""
+    with_executor(f::Function, ::Type{<:SandboxExecutor} = preferred_executor(); kwargs...)
+"""
+function with_executor(f::F, ::Type{T} = preferred_executor();
+                       kwargs...) where {F <: Function, T <: SandboxExecutor}
+    exe = T(; kwargs...)
     try
         return f(exe)
     finally


### PR DESCRIPTION
This allows you to customize the construction of the `SandboxExecutor`.

For example:

```julia
with_executor(DockerExecutor; privileges = :no_new_privileges) do exe
    run(exe, config, `/bin/sh`)
end
```