### PR TITLE
Add `debian_rootfs()`

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,21 +1,22 @@
 [alpine-rootfs]
 git-tree-sha1 = "562768a40e93d27b79fbedf9cfa7883409d494ea"
+lazy = true
 
     [[alpine-rootfs.download]]
     sha256 = "5a588162779446d8e5235bf6fc97588d1e197f44cf64e3a1f88ae828270456a7"
     url = "https://github.com/alpinelinux/docker-alpine/raw/2f3c3015951938c521e752899a92ecd618e0c05b/x86_64/alpine-minirootfs-3.12.4-x86_64.tar.gz"
 
 [debian-minimal-rootfs]
-git-tree-sha1 = "de9327e360568d479ab6a88bb25ac6e1a80ae934"
-lazy=true
+git-tree-sha1 = "771bfb66080028102288ba4303758da8cf1acf0b"
+lazy = true
 
     [[debian-minimal-rootfs.download]]
-    sha256 = "3121c89c1489559c680e42ae2e9cd5f5bdce1de216955a647072a4857252383e"
-    url = "https://github.com/staticfloat/Sandbox.jl/releases/download/debian-minimal-a80ae934/debian_minimal.tar.gz"
+    sha256 = "acc570cedddafa4ae98cae9d387cfb5e2f80a9233f79f61b52ba8762e53431c4"
+    url = "https://github.com/staticfloat/Sandbox.jl/releases/download/debian-minimal-cf1acf0b/debian_minimal.tar.gz"
 
 [julia-alpine-rootfs]
 git-tree-sha1 = "2a09164e817e43448ff352b34e601f5446e8be7e"
-lazy=true
+lazy = true
 
     [[julia-alpine-rootfs.download]]
     sha256 = "846a3aa9350bf23ca1a2bd862c53eae12e5b570ac06f48242a047134cbba78f1"

--- a/contrib/debootstrap_example.jl
+++ b/contrib/debootstrap_example.jl
@@ -1,7 +1,7 @@
 #!/usr/bin/env julia
 
 # This is an example invocation of `debootstrap` to generate a Debian/Ubuntu-based rootfs
-using Scratch, Tar, Pkg, Pkg.Artifacts, SHA
+using Scratch, Tar, Pkg, Pkg.Artifacts, ghr_jll, SHA
 
 if Sys.which("debootstrap") === nothing
     error("Must install `debootstrap`!")
@@ -46,18 +46,27 @@ artifact_hash = create_artifact() do rootfs
     @info("Done!")
 end
 
+# Archive it into a `.tar.gz` file
 @info("Archiving")
 tarball_path = joinpath(@get_scratch!("archived"), "debian_minimal.tar.gz")
 archive_artifact(artifact_hash, tarball_path)
 
-# Bind this artifact into our Artifacts.toml
-tag_name = "debian-minimal-$(bytes2hex(artifact_hash.bytes[end-3:end]))"
-tarball_url = "https://github.com/staticfloat/Sandbox.jl/releases/download/$(tag_name)/$(basename(tarball_path))"
+# Hash the tarball
+@info("Hashing tarball")
 tarball_hash = open(io -> bytes2hex(sha256(io)), tarball_path)
+
+# Upload it to `staticfloat/Sandbox.jl`
+tag_name = "debian-minimal-$(bytes2hex(artifact_hash.bytes[end-3:end]))"
+@info("Uploading to staticfloat/Sandbox.jl@$(tag_name)")
+run(`$(ghr_jll.ghr()) -replace $(tag_name) $(tarball_path)`)
+
+# Bind this artifact into our Artifacts.toml
+tarball_url = "https://github.com/staticfloat/Sandbox.jl/releases/download/$(tag_name)/$(basename(tarball_path))"
 bind_artifact!(
     joinpath(dirname(@__DIR__), "Artifacts.toml"),
     "debian-minimal-rootfs",
     artifact_hash;
     download_info=[(tarball_url, tarball_hash)],
     lazy=true,
+    force=true,
 )

--- a/contrib/steal_docker_julia_alpine.jl
+++ b/contrib/steal_docker_julia_alpine.jl
@@ -1,7 +1,7 @@
 #!/usr/bin/env julia
 
-using Sandbox, Pkg, Pkg.Artifacts, Scratch
-using ghr_jll, SHA
+# This is an example invocation of `pull_docker_image()` to steal the `julia:alpine` image from Docker
+using Sandbox, Pkg, Pkg.Artifacts, Scratch, ghr_jll, SHA
 
 docker_image = "julia:alpine"
 
@@ -34,4 +34,5 @@ bind_artifact!(
     artifact_hash;
     download_info=[(tarball_url, tarball_hash)],
     lazy=true,
+    force=true,
 )

--- a/src/Sandbox.jl
+++ b/src/Sandbox.jl
@@ -256,5 +256,6 @@ end
 # Convenience function for other users who want to do some testing
 alpine_rootfs() = artifact"alpine-rootfs"
 julia_alpine_rootfs() = artifact"julia-alpine-rootfs"
+debian_rootfs() = artifact"debian-minimal-rootfs"
 
 end # module

--- a/test/Sandbox.jl
+++ b/test/Sandbox.jl
@@ -288,14 +288,30 @@ for executor in all_executors
                     Dict("/tmp/rw_dir" => rw_dir),
                 )
 
+                # Test that we can use `wget` (née busybox) within the alpine rootfs to download something
                 socrates_url = "https://github.com/staticfloat/small_bin/raw/master/socrates.tar.xz"
                 socrates_hash = "61bcf109fcb749ee7b6a570a6057602c08c836b6f81091eab7aa5f5870ec6475"
                 with_executor(executor) do exe
                     @test success(run(exe, config, `/bin/sh -c "wget -q $(socrates_url) -O /tmp/rw_dir/$(basename(socrates_url))"`))
-                    socrates_path = joinpath(rw_dir, basename(socrates_url))
-                    @test isfile(socrates_path)
-                    @test open(io -> bytes2hex(sha256(io)), socrates_path) == socrates_hash
                 end
+
+                socrates_path = joinpath(rw_dir, basename(socrates_url))
+                @test isfile(socrates_path)
+                @test open(io -> bytes2hex(sha256(io)), socrates_path) == socrates_hash
+                rm(socrates_path; force=true)
+
+                # Do another test with the debian rootfs where we try to use `apt`
+                ro_mappings["/"] = Sandbox.debian_rootfs()
+                config = SandboxConfig(
+                    ro_mappings,
+                    Dict("/tmp/rw_dir" => rw_dir),
+                    Dict("HOME" => "/root"),
+                )
+                with_executor(executor) do exe
+                    @test success(run(exe, config, `/bin/sh -c "apt update && apt install -y curl && curl -L $(socrates_url) -o /tmp/rw_dir/$(basename(socrates_url))"`))
+                end
+                @test isfile(socrates_path)
+                @test open(io -> bytes2hex(sha256(io)), socrates_path) == socrates_hash
             end
         end
     end


### PR DESCRIPTION
Also add a test to ensure that we can use `apt` and `curl` inside of the
debian rootfs (this isn't so much a sandbox thing as a "this is an
important usecase" thing)