### PR TITLE
Update contrib with a Dockerifle building example

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -21,3 +21,11 @@ lazy = true
     [[julia-alpine-rootfs.download]]
     sha256 = "846a3aa9350bf23ca1a2bd862c53eae12e5b570ac06f48242a047134cbba78f1"
     url = "https://github.com/staticfloat/Sandbox.jl/releases/download/julia-alpine-46e8be7e/julia_alpine.tar.gz"
+
+[debian-julia-python3-rootfs]
+git-tree-sha1 = "dbeb5829a137e6a49337590543daa77f77eae3ba"
+lazy = true
+
+    [[debian-julia-python3-rootfs.download]]
+    sha256 = "58b03f624a1a5b1fb52c4d58a7be62df0bf74e26fa3c160cfe0e821adcc6f7de"
+    url = "https://github.com/staticfloat/Sandbox.jl/releases/download/julia-python3-77eae3ba/julia-python3.tar.gz"

--- a/contrib/Project.toml
+++ b/contrib/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Sandbox = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"

--- a/contrib/docker_build_example/Dockerfile
+++ b/contrib/docker_build_example/Dockerfile
@@ -1,0 +1,13 @@
+# This is an example of how to create a rootfs image from a Dockerfile
+ARG JULIA_VERSION=1.6
+FROM julia:${JULIA_VERSION} as julia_container
+
+# Our base image will be debian
+FROM debian
+
+# Copy julia over from the `julia` container
+COPY --from=julia_container /usr/local/julia /usr/local/julia
+RUN ln -s /usr/local/julia/bin/julia /usr/local/bin/julia
+
+# Install some useful tools
+RUN apt update && apt install -y curl python3

--- a/contrib/docker_build_example/build_docker_image.jl
+++ b/contrib/docker_build_example/build_docker_image.jl
@@ -1,0 +1,37 @@
+#!/usr/bin/env julia
+
+using Sandbox, Pkg.Artifacts, Scratch, SHA, ghr_jll
+
+image_name = "debian-julia-python3"
+run(`docker build -t $(image_name) $(@__DIR__)`)
+
+artifact_hash = create_artifact() do dir
+    @info("Building $(image_name)")
+    Sandbox.export_docker_image(image_name, dir; verbose=true)
+    @info("Hashing")
+end
+
+# Write out to a file
+tarball_path = joinpath(@get_scratch!("archived"), "julia-python3.tar.gz")
+@info("Archiving out to $(tarball_path)")
+archive_artifact(artifact_hash, tarball_path)
+
+# Hash the tarball
+@info("Hashing tarball")
+tarball_hash = open(io -> bytes2hex(sha256(io)), tarball_path)
+
+# Upload to `staticfloat/Sandbox.jl`, create a tag based on this docker image
+tag_name = "$(image_name)-$(bytes2hex(artifact_hash.bytes[end-3:end]))"
+@info("Uploading to staticfloat/Sandbox.jl@$(tag_name)")
+run(`$(ghr_jll.ghr()) -replace $(tag_name) $(tarball_path)`)
+
+# Bind it into `Artifacts.toml`
+tarball_url = "https://github.com/staticfloat/Sandbox.jl/releases/download/$(tag_name)/$(basename(tarball_path))"
+bind_artifact!(
+    joinpath(dirname(dirname(@__DIR__)), "Artifacts.toml"),
+    "$(image_name)-rootfs",
+    artifact_hash;
+    download_info=[(tarball_url, tarball_hash)],
+    lazy=true,
+    force=true,
+)

--- a/src/Sandbox.jl
+++ b/src/Sandbox.jl
@@ -258,5 +258,6 @@ end
 alpine_rootfs() = artifact"alpine-rootfs"
 julia_alpine_rootfs() = artifact"julia-alpine-rootfs"
 debian_rootfs() = artifact"debian-minimal-rootfs"
+julia_python3_rootfs() = artifact"debian-julia-python3-rootfs"
 
 end # module


### PR DESCRIPTION
Also add the `julia` and `python3` debgian rootfs as an example of how
to build something a little more chunky.