### PR TITLE
Use `gtar` if it is available; otherwise, use `tar`

### DIFF
--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -93,7 +93,8 @@ function build_docker_image(root_path::String, uid::Cint, gid::Cint; verbose::Bo
         open(`docker import - $(image_name)`, "w", verbose ? stdout : devnull) do io
             # we need to record permisions, so can't use Tar.jl
             cd(root_path) do
-                run(pipeline(`tar -c --owner=$(uid) --group=$(gid) .`, stdout=io))
+                tar = Sys.which("gtar") !== nothing ? "gtar" : "tar"
+                run(pipeline(`$(tar) -c --owner=$(uid) --group=$(gid) .`, stdout=io))
             end
         end
 


### PR DESCRIPTION
The BSD `tar` that ships with macOS does not support `--owner=0`. It's easy enough for macOS users to install GNU tar (e.g. via Homebrew), so Sandbox.jl should try to use GNU tar if it is available.