### PR TITLE
Add the optional `--tmpfs-size` command-line option to the user namespace sandbox

### DIFF
--- a/deps/userns_sandbox.c
+++ b/deps/userns_sandbox.c
@@ -432,10 +432,11 @@ static void mount_the_world(const char * root_dir,
     // Create tmpfs to store ephemeral changes.  These changes are lost once
     // the `tmpfs` is unmounted, which occurs when all processes within the
     // namespace exit and the mount namespace is destroyed.
-    char * options = NULL;
-    check(0 < asprintf(&options, "size=%s", tmpfs_size));
+    char options[32];
+    int n = snprintf(options, 32, "size=%s", tmpfs_size);
+    check(0 < n);
+    check(n < 31);
     check(0 == mount("tmpfs", "/proc", "tmpfs", 0, options));
-    free(options);
   }
 
   if (verbose) {

--- a/src/SandboxConfig.jl
+++ b/src/SandboxConfig.jl
@@ -55,6 +55,7 @@ struct SandboxConfig
     multiarch_formats::Vector{BinFmtRegistration}
     uid::Cint
     gid::Cint
+    tmpfs_size::Union{String, Nothing}
 
     stdin::AnyRedirectable
     stdout::AnyRedirectable
@@ -70,6 +71,7 @@ struct SandboxConfig
                            multiarch::Vector{<:Platform} = Platform[],
                            uid::Integer=0,
                            gid::Integer=0,
+                           tmpfs_size::Union{String, Nothing}=nothing,
                            stdin::AnyRedirectable = Base.devnull,
                            stdout::AnyRedirectable = Base.stdout,
                            stderr::AnyRedirectable = Base.stderr,
@@ -112,6 +114,6 @@ struct SandboxConfig
             push!(multiarch_formats, platform_qemu_registrations[interp_platforms[platform_idx]])
         end
 
-        return new(read_only_maps, read_write_maps, env, entrypoint, pwd, persist, collect(multiarch_formats), Cint(uid), Cint(gid), stdin, stdout, stderr, verbose)
+        return new(read_only_maps, read_write_maps, env, entrypoint, pwd, persist, collect(multiarch_formats), Cint(uid), Cint(gid), tmpfs_size, stdin, stdout, stderr, verbose)
     end
 end

--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -153,6 +153,11 @@ function build_executor_command(exe::UserNamespacesExecutor, config::SandboxConf
     # Set the user and group, if requested
     append!(cmd_string, ["--uid", string(config.uid), "--gid", string(config.gid)])
 
+    # Set the custom tmpfs_size, if requested
+    if config.tmpfs_size !== nothing
+        append!(cmd_string, ["--tmpfs-size", config.tmpfs_size])
+    end
+
     # If we're running in privileged mode, we need to add `sudo` (or `su`, if `sudo` doesn't exist)
     if isa(exe, PrivilegedUserNamespacesExecutor)
         # Next, prefer `sudo`, but allow fallback to `su`. Also, force-set our


### PR DESCRIPTION
This PR adds the optional `--tmpfs-size` command-line option to the user namespace sandbox. 

If the option is not provided, it falls back to the default value of `"1G"`.