### PR TITLE
Use Tar_jll.jl to provide a GNU tar binary (instead of relying on the system tar)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,10 +12,12 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+Tar_jll = "9b64493d-8859-5bf3-93d7-7c32dd38186f"
 UserNSSandbox_jll = "b88861f7-1d72-59dd-91e7-a8cc876a4984"
 
 [compat]
 Preferences = "1.2.1"
 Scratch = "1"
+Tar_jll = "=1.32.0"
 UserNSSandbox_jll = "2021.8.18"
 julia = "1.6"


### PR DESCRIPTION
Some systems (e.g. macOS) ship by default with a BSD `tar` that does not support the `--owner` and `--group` command-line options.

This PR adds Tar_jll.jl as a dependency and uses it to provide a GNU `tar` so that we do not have to rely on the system `tar`.

If Tar_jll is not supported on the platform, we fall back to the system `tar`.