### PR TITLE
Test suite: Inside the nested child, don't use the Pkg server

### DIFF
--- a/test/nested/nested_child.jl
+++ b/test/nested/nested_child.jl
@@ -12,6 +12,7 @@ for element in readdir(original_app_directory)
     cp(old_path, new_path; force = true)
 end
 rm.(joinpath.(Ref(new_app_directory), Base.manifest_names); force = true)
+ENV["JULIA_PKG_SERVER"] = ""
 using Pkg
 Pkg.activate(new_app_directory)
 Pkg.instantiate()


### PR DESCRIPTION
I think that, inside the nested child, the Pkg server might be giving us old versions of packages and JLLs.