### PR TITLE
If the Linux kernel version cannot be parsed, do not assume it is >= 3.18

### DIFF
--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -73,7 +73,9 @@ end
 
 function check_kernel_version(;verbose::Bool = false)
     # Don't bother to do anything on non-Linux
-    Sys.islinux() || return false
+    if !Sys.islinux()
+        return false
+    end
     kernel_version = get_kernel_version()
 
     # If we were unable to parse any part of the version number, then warn and exit.

--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -73,15 +73,13 @@ end
 
 function check_kernel_version(;verbose::Bool = false)
     # Don't bother to do anything on non-Linux
-    if !Sys.islinux()
-        return true
-    end
+    Sys.islinux() || return false
     kernel_version = get_kernel_version()
 
     # If we were unable to parse any part of the version number, then warn and exit.
     if kernel_version === nothing
-        @warn("Unable to check version number; assuming kernel version >= 3.18")
-        return true
+        @warn("Unable to check version number")
+        return false
     end
 
     # Otherwise, we have a kernel version and if it's too old, we should freak out.


### PR DESCRIPTION
If I understand correctly, one of the reasons that we require the Linux kernel version to be at least 3.18 is because 3.18 contains some security fixes for user namespaces.

E.g. from https://sylabs.io/guides/3.5/admin-guide/user_namespace.html:
> To allow unprivileged creation of user namespaces a kernel >=3.8 is required, with >=3.18 being recommended due to security fixes for user namespaces (3.18 also adds OverlayFS support which is used by Singularity).

Since the security fixes are not available before 3.18, I think we should err on the side of caution.

Therefore, if for some reason we are not able to parse the kernel version, we should not assume that the kernel version is >= 3.18, because if we make that assumption and it is incorrect, we would be using user namespaces with a kernel that is < 3.18, and thus we would not have the security fixes.

---

Also, on Alpine, we can't use libc to get the kernel version, so I added code that looks for musl if libc is not found.