### PR TITLE
CI: Fix the names of the CI jobs so that they include whether or not we are building the sandbox locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - ${{ matrix.julia-arch }} - ${{ matrix.build-sandbox }}
+    name: Julia ${{ matrix.julia-version }} - ${{ matrix.julia-arch }} - ${{ matrix.build-local-sandbox }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - ${{ matrix.julia-arch }} - ${{ matrix.build-local-sandbox }}
+    name: ${{ matrix.julia-version }}/${{ matrix.julia-arch }}/build-local-sandbox=${{ matrix.build-local-sandbox }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.julia-version }}/${{ matrix.julia-arch }}/build-local-sandbox=${{ matrix.build-local-sandbox }}
+    name: Julia ${{ matrix.julia-version }} ${{ matrix.julia-arch }} build_local=${{ matrix.build-local-sandbox }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
A typo in the YAML file was causing the names of CI jobs to not include the boolean that indicates whether or not we are building the sandbox locally.