### PR TITLE
When registering binfmt_misc entries, print an `@info` message about sudo even if `verbose` is `false`

### DIFF
--- a/src/binfmt_misc.jl
+++ b/src/binfmt_misc.jl
@@ -246,6 +246,8 @@ function register_requested_formats!(formats::Vector{BinFmtRegistration}; verbos
         msg = "Registering $(length(formats_to_register)) binfmt_misc entries, this may ask for your `sudo` password."
         if verbose
             @info(msg, formats=format_names)
+        elseif (Sys.which("sudo") !== nothing) && (success(`sudo -k -n true`))
+            # in this case, we know that `sudo` will not prompt the user for a password
         else
             @info(msg)
         end

--- a/src/binfmt_misc.jl
+++ b/src/binfmt_misc.jl
@@ -135,7 +135,7 @@ function BinFmtRegistration(file::String)
     if !enabled
         return nothing
     end
-    
+
     return BinFmtRegistration(basename(file), interpreter, flags, offset, magic, mask)
 end
 
@@ -242,9 +242,12 @@ function register_requested_formats!(formats::Vector{BinFmtRegistration}; verbos
 
     # Notify the user if we have any formats to register, then register them.
     if !isempty(formats_to_register)
+        format_names = sort([f.name for f in formats_to_register])
+        msg = "Registering $(length(formats_to_register)) binfmt_misc entries, this may ask for your `sudo` password."
         if verbose
-            format_names = sort([f.name for f in formats_to_register])
-            @info("Registering $(length(formats_to_register)) binfmt_misc entries, this may ask for your `sudo` password.", formats=format_names)
+            @info(msg, formats=format_names)
+        else
+            @info(msg)
         end
         write_binfmt_misc_registration!.(formats_to_register)
     end
@@ -311,7 +314,7 @@ const platform_qemu_registrations = Dict(
     Platform("ppc64le", "linux"; libc="musl") => qemu_ppc64le,
 )
 
-# Define what is a natively-runnable 
+# Define what is a natively-runnable
 const host_arch = arch(HostPlatform())
 function natively_runnable(p::Platform)
     if host_arch == "x86_64"


### PR DESCRIPTION
Users will probably wonder why they are being asked for their `sudo` password (especially if they want to use the unprivileged user namespaces executor), so we should always show the `@info` message explaining why, even if `verbose` is `false`.