### PR TITLE
For the `warn_priviledged` function, use `maxlog=1` instead of using a global variable

### DIFF
--- a/src/Sandbox.jl
+++ b/src/Sandbox.jl
@@ -103,13 +103,9 @@ function preferred_executor(;verbose::Bool = false)
 end
 
 # Helper function for warning about privileged execution trying to invoke `sudo`
-prompted_userns_privileged = false
 function warn_priviledged(::PrivilegedUserNamespacesExecutor)
-    global prompted_userns_privileged
-    if !prompted_userns_privileged
-        @info("Running privileged container via `sudo`, may ask for your password:")
-        prompted_userns_privileged = true
-    end
+    @info("Running privileged container via `sudo`, may ask for your password:", maxlog=1)
+    return nothing
 end
 warn_priviledged(::SandboxExecutor) = nothing
 

--- a/test/UserNamespaces.jl
+++ b/test/UserNamespaces.jl
@@ -44,7 +44,7 @@ end
 if success(`sudo -k -n true`)
     if executor_available(PrivilegedUserNamespacesExecutor)
         @testset "PrivilegedUserNamespacesExecutor" begin
-            @test_logs (:info, "Testing Privileged User Namespaces Executor (read-only, read-write)") begin
+            @test_logs (:info, "Testing Privileged User Namespaces Executor (read-only, read-write)") match_mode=:any begin
                 with_executor(PrivilegedUserNamespacesExecutor) do exe
                     @test probe_executor(exe; test_read_only_map=true, test_read_write_map=true, verbose=true)
                 end


### PR DESCRIPTION
Using the `maxlog=1` kwarg accomplishes the same thing without requiring us to manage a global variable.

For example:

```julia
julia> function warn_priviledged()
           @info("Running privileged container via `sudo`, may ask for your password:", maxlog=1)
           return nothing
       end
warn_priviledged (generic function with 1 method)

julia> warn_priviledged()
[ Info: Running privileged container via `sudo`, may ask for your password:

julia> warn_priviledged()

julia> warn_priviledged()

julia> warn_priviledged()
```