### PR TITLE
Add `hostname` option to `SandboxConfig`

### DIFF
--- a/deps/userns_sandbox.c
+++ b/deps/userns_sandbox.c
@@ -300,7 +300,7 @@ static void bind_mount(const char *src, const char *dest, char read_only) {
     }
   }
 
-  if (resolved_src[0] == NULL) {
+  if (resolved_src[0] == '\0') {
     strncpy(resolved_src, src, PATH_MAX);
   }
 

--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -189,6 +189,10 @@ function build_executor_command(exe::DockerExecutor, config::SandboxConfig, user
         append!(cmd_string, ["--entrypoint", config.entrypoint])
     end
 
+    if config.hostname !== nothing
+        append!(cmd_string, ["--hostname", config.hostname])
+    end
+
     # For each platform requested by `multiarch`, ensure its matching interpreter is registered,
     # but only if we're on Linux.  If we're on some other platform, like macOS where Docker is
     # implemented with a virtual machine, we just trust the docker folks to have set up the

--- a/src/SandboxConfig.jl
+++ b/src/SandboxConfig.jl
@@ -43,6 +43,8 @@ Sandbox executors require a configuration to set up the environment properly.
 - `stdin`, `stdout`, `stderr`: input/output streams for the sandboxed process.
   - Can be any kind of `IO`, `TTY`, `devnull`, etc...
 
+- `hostname`: Set the hostname within the sandbox, defaults to the current hostname
+
 - `verbose`: Set whether the sandbox construction process should be more or less verbose.
 """
 struct SandboxConfig
@@ -56,6 +58,7 @@ struct SandboxConfig
     uid::Cint
     gid::Cint
     tmpfs_size::Union{String, Nothing}
+    hostname::Union{String, Nothing}
 
     stdin::AnyRedirectable
     stdout::AnyRedirectable
@@ -72,6 +75,7 @@ struct SandboxConfig
                            uid::Integer=0,
                            gid::Integer=0,
                            tmpfs_size::Union{String, Nothing}=nothing,
+                           hostname::Union{String, Nothing}=nothing,
                            stdin::AnyRedirectable = Base.devnull,
                            stdout::AnyRedirectable = Base.stdout,
                            stderr::AnyRedirectable = Base.stderr,
@@ -114,6 +118,6 @@ struct SandboxConfig
             push!(multiarch_formats, platform_qemu_registrations[interp_platforms[platform_idx]])
         end
 
-        return new(read_only_maps, read_write_maps, env, entrypoint, pwd, persist, collect(multiarch_formats), Cint(uid), Cint(gid), tmpfs_size, stdin, stdout, stderr, verbose)
+        return new(read_only_maps, read_write_maps, env, entrypoint, pwd, persist, collect(multiarch_formats), Cint(uid), Cint(gid), tmpfs_size, hostname, stdin, stdout, stderr, verbose)
     end
 end

--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -184,6 +184,10 @@ function build_executor_command(exe::UserNamespacesExecutor, config::SandboxConf
         append!(cmd_string, ["--tmpfs-size", config.tmpfs_size])
     end
 
+    if config.hostname !== nothing
+        append!(cmd_string, ["--hostname", config.hostname])
+    end
+
     # If we're running in privileged mode, we need to add `sudo` (or `su`, if `sudo` doesn't exist)
     if isa(exe, PrivilegedUserNamespacesExecutor)
         # Next, prefer `sudo`, but allow fallback to `su`. Also, force-set our

--- a/test/Sandbox.jl
+++ b/test/Sandbox.jl
@@ -280,6 +280,20 @@ for executor in all_executors
             end
         end
 
+        @testset "hostname" begin
+            stdout = IOBuffer()
+
+            config = SandboxConfig(
+                Dict("/" => rootfs_dir);
+                stdout,
+                hostname="sandy",
+            )
+            with_executor(executor) do exe
+                @test success(exe, config, `/bin/uname -n`)
+                @test chomp(String(take!(stdout))) == "sandy"
+            end
+        end
+
         @testset "Internet access" begin
             mktempdir() do rw_dir
                 ro_mappings = Dict(

--- a/test/SandboxConfig.jl
+++ b/test/SandboxConfig.jl
@@ -14,6 +14,7 @@ using Test, LazyArtifacts, Sandbox
         @test config.stdin == Base.devnull
         @test config.stdout == Base.stdout
         @test config.stderr == Base.stderr
+        @test config.hostname === nothing
     end
 
     @testset "full options" begin
@@ -33,7 +34,8 @@ using Test, LazyArtifacts, Sandbox
             persist = true,
             stdin = Base.stdout,
             stdout = stdout,
-            stderr = Base.devnull
+            stderr = Base.devnull,
+            hostname="sandy",
         )
         @test config.read_only_maps["/"] == rootfs_dir
         @test config.read_only_maps["/lib"] == "/lib"
@@ -45,6 +47,7 @@ using Test, LazyArtifacts, Sandbox
         @test config.stdin == Base.stdout
         @test config.stdout == stdout
         @test config.stderr == Base.devnull
+        @test config.hostname == "sandy"
     end
 
     @testset "errors" begin


### PR DESCRIPTION
This allows us to launch sandboxes with a deterministic hostname, if we so desire to.  Useful for things like fully reproducible builds, etc...

Closes https://github.com/staticfloat/Sandbox.jl/issues/64