### PR TITLE
Don't recurse into links when setting permissions.

### DIFF
--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -28,7 +28,7 @@ function chmod_recursive(root::String, perms, use_sudo::Bool)
                 rethrow(e)
             end
         end
-        if isdir(path)
+        if isdir(path) && !islink(path)
             chmod_recursive(path, perms, use_sudo)
         end
     end


### PR DESCRIPTION
Fixes https://github.com/JuliaCI/PkgEval.jl/issues/98, where every package depending on Arrow.jl fails to clean up.

```
┌ Error: Unexpected error while cleaning up process
│   exception =
│    IOError: stat("/tmp/jl_lXgiOx/upper/rootfs/home/pkgeval/.julia/packages/Arrow/PQ5Mm/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github/pkgs/Arrow.jl/.github"): too many symbolic links encountered (ELOOP)
│    Stacktrace:
│     [1] uv_error
│       @ ./libuv.jl:97 [inlined]
│     [2] stat(path::String)
│       @ Base.Filesystem ./stat.jl:152
│     [3] isdir
│       @ ./stat.jl:456 [inlined]
│     [4] chmod_recursive(root::String, perms::UInt16, use_sudo::Bool)
│       @ Sandbox /storage/pkgeval/depot/packages/Sandbox/aUsDe/src/UserNamespaces.jl:31
│     [5] chmod_recursive(root::String, perms::UInt16, use_sudo::Bool) (repeats 71 times)
│       @ Sandbox /storage/pkgeval/depot/packages/Sandbox/aUsDe/src/UserNamespaces.jl:32
│     [6] cleanup(exe::Sandbox.UnprivilegedUserNamespacesExecutor)
│       @ Sandbox /storage/pkgeval/depot/packages/Sandbox/aUsDe/src/UserNamespaces.jl:41
│     [7] macro expansion
│       @ /storage/pkgeval/depot/packages/PkgEval/rd3Bb/src/run.jl:69 [inlined]
│     [8] (::PkgEval.var"#38#39"{Base.Process, Sandbox.UnprivilegedUserNamespacesExecutor})()
│       @ PkgEval ./task.jl:423
└ @ PkgEval /storage/pkgeval/depot/packages/PkgEval/rd3Bb/src/run.jl:71
```

Would be nice to get this in a release!