### PR TITLE
[Docker] Add platform argument to `pull_docker_image`

### DIFF
--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -275,16 +275,19 @@ end
 """
     pull_docker_image(image::String,
                       output_dir::String = <default scratch location>;
+                      platform::String = "",
                       verbose::Bool = false,
                       force::Bool = false)
 
 Pulls and saves the given docker image name to the requested output directory.
 Useful for pulling down a known good rootfs image from Docker Hub, for future use
 by Sandbox executors.  If `force` is set to true, will overwrite a pre-existing
-directory, otherwise will silently return.
+directory, otherwise will silently return.  Optionally specify the platform of the
+image with `platform`.
 """
 function pull_docker_image(image_name::String,
                            output_dir::String = @get_scratch!("docker-$(sanitize_key(image_name))");
+                           platform::String = "",
                            force::Bool = false,
                            verbose::Bool = false)
     if ispath(output_dir) && !isempty(readdir(output_dir))
@@ -300,7 +303,8 @@ function pull_docker_image(image_name::String,
 
     # Pull the latest version of the image
     try
-        run(`docker pull $(image_name)`)
+        p = isempty(platform) ? `` : `--platform $(platform)`
+        run(`docker pull $(p) $(image_name)`)
     catch
         if verbose
             @warn("Cannot pull", image_name)

--- a/test/Docker.jl
+++ b/test/Docker.jl
@@ -60,10 +60,10 @@ if executor_available(DockerExecutor)
 
         @testset "pull_docker_image" begin
             with_temp_scratch() do
-                julia_rootfs = Sandbox.pull_docker_image("julia:alpine"; force=true, verbose=true)
+                julia_rootfs = Sandbox.pull_docker_image("julia:alpine"; force=true, verbose=true, platform="linux/amd64")
 
                 @test_logs (:warn, r"Will not overwrite") begin
-                    other_julia_rootfs = Sandbox.pull_docker_image("julia:alpine"; verbose=true)
+                    other_julia_rootfs = Sandbox.pull_docker_image("julia:alpine"; verbose=true, platform="linux/amd64")
                     @test other_julia_rootfs == julia_rootfs
                 end
 


### PR DESCRIPTION
On aarch64 platforms tests would try to pull the Julia alpine image for that
platform, but there is only for `x86_64`.  With this change we can specify the
platform and force `linux/amd64` for this image.

With this change some tests pass on the M1, but they eventually fail because
#51 forced `Tar_jll` 1.32 which isn't available for this platform.