### PR TITLE
Allow using `Tar_jll` v1.34

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,6 @@ UserNSSandbox_jll = "b88861f7-1d72-59dd-91e7-a8cc876a4984"
 [compat]
 Preferences = "1.2.1"
 Scratch = "1"
-Tar_jll = "=1.32.0"
+Tar_jll = "1.34.0"
 UserNSSandbox_jll = "2022.1.6"
 julia = "1.6"

--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -98,11 +98,8 @@ function build_docker_image(root_path::String, uid::Cint, gid::Cint; verbose::Bo
             # available, we use the GNU tar provided by Tar_jll. If Tar_jll is not available,
             # we fall back to the system tar.
             cd(root_path) do
-            # tar = Tar_jll.is_available() ? Tar_jll.tar() : `tar`
-            # run(pipeline(`$(tar) -c --owner=$(uid) --group=$(gid) .`, stdout=io))
-            Tar_jll.tar() do tar
+                tar = Tar_jll.is_available() ? Tar_jll.tar() : `tar`
                 run(pipeline(`$(tar) -c --owner=$(uid) --group=$(gid) .`, stdout=io))
-            end
             end
         end
 


### PR DESCRIPTION
This has the new `JLLWrappers`-based interface which provides the function
`is_available` to query availability and also supports more platforms than the
build of v1.32.