### PR TITLE
Bind-mount `/dev/random` in as well

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,15 @@ Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Tar_jll = "9b64493d-8859-5bf3-93d7-7c32dd38186f"
 UserNSSandbox_jll = "b88861f7-1d72-59dd-91e7-a8cc876a4984"
 
+[extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Pkg", "Test"]
+
 [compat]
-Preferences = "1.2.1"
+Preferences = "1.2.5"
 Scratch = "1"
 Tar_jll = "1.34.0"
 UserNSSandbox_jll = "2022.1.6"

--- a/deps/build_local_sandbox.jl
+++ b/deps/build_local_sandbox.jl
@@ -8,9 +8,9 @@ sandbox_src = joinpath(@__DIR__, "userns_sandbox.c")
 run(`cc -std=c99 -O2 -static -static-libgcc -g -o $(sandbox_path) $(sandbox_src)`)
 
 # Tell UserNSSandbox_jll to load our `sandbox` instead of the default artifact one
+jll_uuid = Base.UUID("b88861f7-1d72-59dd-91e7-a8cc876a4984")
 set_preferences!(
-    joinpath(dirname(@__DIR__), "LocalPreferences.toml"),
-    "UserNSSandbox_jll",
+    jll_uuid,
     "sandbox_path" => sandbox_path;
     force=true,
 )

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,0 @@
-[deps]
-LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-Scratch = "6c6a2e73-6563-6170-7368-637461726353"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-UserNSSandbox_jll = "b88861f7-1d72-59dd-91e7-a8cc876a4984"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,8 @@
 REPO_ROOT = dirname(@__DIR__)
 should_build_local_sandbox = parse(Bool, get(ENV, "SANDBOX_BUILD_LOCAL_SANDBOX", "false"))
 if should_build_local_sandbox
-    run(`$(Base.julia_cmd()) --project=$(REPO_ROOT) $(REPO_ROOT)/deps/build_local_sandbox.jl`)
-    # Ensure LocalPreferences.toml gets used by test project as well
-    # This is a workaround for https://github.com/JuliaLang/Pkg.jl/issues/2500
-    # Note that we copy to `Base.active_project()`, which is often the temporary project that `Pkg.test()` creates
-    cp(joinpath(REPO_ROOT, "LocalPreferences.toml"), joinpath(dirname(Base.active_project()), "LocalPreferences.toml"))
+    @info("Building local sandbox")
+    run(`$(Base.julia_cmd()) --project=$(Base.active_project()) $(REPO_ROOT)/deps/build_local_sandbox.jl`)
 else
     # Clear out any `LocalPreferences.toml` files that we may or may not have.
     for prefix in (REPO_ROOT, joinpath(REPO_ROOT, "test"))


### PR DESCRIPTION
This is needed for `gpg-agent`, and all users of `libgcrypt`,
apparently.

X-ref: https://github.com/gpg/libgcrypt/blob/9c42db0b379c277ee976fcc696e84e31863a85a8/random/random-csprng.c#L1205-L1210