### PR TITLE
Improve sandbox `run()` wrapper to support `wait=false`.

### DIFF
--- a/src/Sandbox.jl
+++ b/src/Sandbox.jl
@@ -124,12 +124,18 @@ for f in (:run, :success)
             ret = $f(cmd; kwargs...)
 
             # If we were using temporary IOBuffers, write the result out to `config.std{out,err}`
-            if isa(temp_stdout, IOBuffer)
-                write(config.stdout, take!(temp_stdout))
+            @async begin
+                if isa(ret, Base.Process)
+                    wait(ret)
+                end
+                if isa(temp_stdout, IOBuffer)
+                    write(config.stdout, take!(temp_stdout))
+                end
+                if isa(temp_stderr, IOBuffer)
+                    write(config.stderr, take!(temp_stderr))
+                end
             end
-            if isa(temp_stderr, IOBuffer)
-                write(config.stderr, take!(temp_stderr))
-            end
+            yield()
             return ret
         end
     end


### PR DESCRIPTION
This solution is not totally satisfactory, as it seems a little race-y.
It would be better if we somehow were able to return the `Task` given by
the `@async`, but if we do that, we can't do things like send signals to
the process we just launched, because we're no longer returning a
`Base.Process`, we're returning a `Task`.