### PR TITLE
Signal handling

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -15,12 +15,12 @@ lazy = true
     url = "https://github.com/staticfloat/Sandbox.jl/releases/download/julia-python3-77eae3ba/julia-python3.tar.gz"
 
 [debian-minimal-rootfs]
-git-tree-sha1 = "f2dd967ccbf4ab29781388f5848f8d17a4a4e0bc"
+git-tree-sha1 = "f95ec236cb14157ed9f1e34216e20addde333cb6"
 lazy = true
 
     [[debian-minimal-rootfs.download]]
-    sha256 = "7e5f2625e6ca9a105430e0a505896184b503dfc3a7ce15916d2b8dca0391e65d"
-    url = "https://github.com/JuliaCI/rootfs-images/releases/download/v4.4/debian_minimal.x86_64.tar.gz"
+    sha256 = "167169c8890074e0629dba7b6ba0369d2958cdf0bd446ffb279b4dcf788a2cb9"
+    url = "https://github.com/JuliaCI/rootfs-images/releases/download/v5.7/debian_minimal.x86_64.tar.gz"
 
 [julia-alpine-rootfs]
 git-tree-sha1 = "2a09164e817e43448ff352b34e601f5446e8be7e"

--- a/deps/userns_sandbox.c
+++ b/deps/userns_sandbox.c
@@ -773,6 +773,9 @@ int main(int sandbox_argc, char **sandbox_argv) {
         break;
       case 'e':
         entrypoint = strdup(optarg);
+        if (verbose) {
+          fprintf(stderr, "Parsed --entrypoint as \"%s\"\n", entrypoint);
+        }
         break;
       case 't':
         tmpfs_size = strdup(optarg);
@@ -782,6 +785,9 @@ int main(int sandbox_argc, char **sandbox_argv) {
         break;
       case 'H':
         hostname = strdup(optarg);
+        if (verbose) {
+          fprintf(stderr, "Parsed --hostname as \"%s\"\n", hostname);
+        }
         break;
       default:
         fputs("getoptlong defaulted?!\n", stderr);

--- a/src/Sandbox.jl
+++ b/src/Sandbox.jl
@@ -111,7 +111,7 @@ warn_priviledged(::SandboxExecutor) = nothing
 
 for f in (:run, :success)
     @eval begin
-        function $f(exe::SandboxExecutor, config::SandboxConfig, user_cmd::Cmd; kwargs...)
+        function $f(exe::SandboxExecutor, config::SandboxConfig, user_cmd::Cmd)
             # Because Julia 1.8+ closes IOBuffers like `stdout` and `stderr`, we create temporary
             # IOBuffers that get copied over to the persistent `stdin`/`stdout` after the run is complete.
             temp_stdout = isa(config.stdout, IOBuffer) ? IOBuffer() : config.stdout
@@ -121,7 +121,7 @@ for f in (:run, :success)
                 @info("Running sandboxed command", user_cmd.exec)
             end
             warn_priviledged(exe)
-            ret = $f(cmd; kwargs...)
+            ret = $f(cmd)
 
             # If we were using temporary IOBuffers, write the result out to `config.std{out,err}`
             if isa(temp_stdout, IOBuffer)


### PR DESCRIPTION
We want to be able to send things like  `SIGTERM` to the process we
started in the sandbox, and so we forward many useful signals through.
If our child then dies with a signal, we find a way to pass this
information back up to the parent.

Note that I am not totally happy with the implementation here, as if a
child exits with a status of `143`, then the sandbox will assume that it
was actually a `SIGTERM`.  We should probably create some kind of
out-of-band information that says that a child signaled, or we should
somehow fix the fact that PID 1 in a namespace can't SIGTERM itself.