### PR TITLE
Bump required version of UserNSSandbox_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,5 +26,5 @@ test = ["Pkg", "Test"]
 Preferences = "1.2.5"
 Scratch = "1"
 Tar_jll = "1.34.0"
-UserNSSandbox_jll = "2022.1.6"
+UserNSSandbox_jll = "2022.3.30"
 julia = "1.6"


### PR DESCRIPTION
This new version required for recent signal handling features.