### PR TITLE
RFC: Add support for overlay maps

### DIFF
--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -194,18 +194,18 @@ function build_executor_command(exe::DockerExecutor, config::SandboxConfig, user
             # overlayfs on top of the container's filesystem
             tmpfs_size = something(config.tmpfs_size, "1G")
             println(io, """
-                mkdir /var/persist
-                mount -t tmpfs -osize=$(tmpfs_size) tmpfs /var/persist""")
+                /bin/mkdir /var/persist
+                /bin/mount -t tmpfs -osize=$(tmpfs_size) tmpfs /var/persist""")
         end
         ## Overlay read-only maps
         for (dst, src) in read_only_maps
             println(io, """
-                mkdir -p /var/persist/upper/$dst /var/persist/work/$dst
-                mount -t overlay overlay -o lowerdir=$dst,upperdir=/var/persist/upper/$dst,workdir=/var/persist/work/$dst $dst""")
+                /bin/mkdir -p /var/persist/upper/$dst /var/persist/work/$dst
+                /bin/mount -t overlay overlay -o lowerdir=$dst,upperdir=/var/persist/upper/$dst,workdir=/var/persist/work/$dst $dst""")
         end
         ## Execute user-specified scripts
         if config.entrypoint !== nothing
-            println(io, config.entrypoint)
+            println(io, "exec $(config.entrypoint) \"\$@\"")
         else
             println(io, "exec \"\$@\"")
         end

--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -171,6 +171,10 @@ function build_executor_command(exe::DockerExecutor, config::SandboxConfig, user
         append!(cmd_string, ["-v", "$(src):$(dst)"])
     end
 
+    # Check for overlay mappings
+    isempty(config.overlay_maps) ||
+        throw(ArgumentError("DockerExecutor does not support overlay mappings"))
+
     # Apply environment mappings, first from `config`, next from `user_cmd`.
     for (k, v) in config.env
         append!(cmd_string, ["-e", "$(k)=$(v)"])

--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -171,10 +171,6 @@ function build_executor_command(exe::DockerExecutor, config::SandboxConfig, user
         append!(cmd_string, ["-v", "$(src):$(dst)"])
     end
 
-    # Check for overlay mappings
-    isempty(config.overlay_maps) ||
-        throw(ArgumentError("DockerExecutor does not support overlay mappings"))
-
     # Apply environment mappings, first from `config`, next from `user_cmd`.
     for (k, v) in config.env
         append!(cmd_string, ["-e", "$(k)=$(v)"])

--- a/src/SandboxConfig.jl
+++ b/src/SandboxConfig.jl
@@ -7,6 +7,7 @@ const AnyRedirectable = Union{Base.AbstractCmd, Base.TTY, <:IO}
 Sandbox executors require a configuration to set up the environment properly.
 
 - `read_only_maps`: Directories that are mapped into the sandbox as read-only mappings.
+  Modifications to these directories are supported, and will go to the persistence dir.
    - Specified as pairs, e.g. `sandbox_path => host_path`.  All paths must be absolute.
    - Must always include a mapping for root, e.g. `"/" => rootfs_path`.
 
@@ -14,12 +15,6 @@ Sandbox executors require a configuration to set up the environment properly.
    - Specified as pairs, e.g. `sandbox_path => host_path`.  All paths must be absolute.
    - Note that some executors may not show perfect live updates; consistency is guaranteed
      only after execution is finished.
-
-- `overlay_maps`: Directories that are used to store changes made to the sandbox filesystem.
-  This can be used to support modifications to `read_only_maps`, much like `persist` is used
-  to support modifications to the root filesystem.
-   - Specified as pairs, e.g. `sandbox_path => host_path`.  All paths must be absolute.
-   - Currently only supported on the user namespace executors.
 
 - `env`: Dictionary mapping of environment variables that should be set within the sandbox.
 
@@ -56,7 +51,6 @@ Sandbox executors require a configuration to set up the environment properly.
 struct SandboxConfig
     read_only_maps::Dict{String,String}
     read_write_maps::Dict{String,String}
-    overlay_maps::Dict{String,String}
     env::Dict{String,String}
     entrypoint::Union{String,Nothing}
     pwd::String
@@ -75,7 +69,6 @@ struct SandboxConfig
     function SandboxConfig(read_only_maps::Dict{String,String},
                            read_write_maps::Dict{String,String} = Dict{String,String}(),
                            env::Dict{String,String} = Dict{String,String}();
-                           overlay_maps::Dict{String,String} = Dict{String,String}(),
                            entrypoint::Union{String,Nothing} = nothing,
                            pwd::String = "/",
                            persist::Bool = false,
@@ -98,7 +91,7 @@ struct SandboxConfig
         end
 
         # Don't touch anything that is encrypted; it doesn't play well with user namespaces or docker
-        for path in [values(read_only_maps)...; values(read_write_maps)...; values(overlay_maps)...]
+        for path in [values(read_only_maps)...; values(read_write_maps)...]
             crypt, mountpoint = is_ecryptfs(path; verbose)
             if crypt
                 throw(ArgumentError("Path $(path) is mounted on the ecryptfs filesystem $(mountpoint)!"))
@@ -126,6 +119,6 @@ struct SandboxConfig
             push!(multiarch_formats, platform_qemu_registrations[interp_platforms[platform_idx]])
         end
 
-        return new(read_only_maps, read_write_maps, overlay_maps, env, entrypoint, pwd, persist, collect(multiarch_formats), Cint(uid), Cint(gid), tmpfs_size, hostname, stdin, stdout, stderr, verbose)
+        return new(read_only_maps, read_write_maps, env, entrypoint, pwd, persist, collect(multiarch_formats), Cint(uid), Cint(gid), tmpfs_size, hostname, stdin, stdout, stderr, verbose)
     end
 end

--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -160,11 +160,6 @@ function build_executor_command(exe::UserNamespacesExecutor, config::SandboxConf
         append!(cmd_string, ["--workspace", "$(src):$(dst)"])
     end
 
-    # Add in overlay mappings
-    for (dst, src) in config.overlay_maps
-        append!(cmd_string, ["--overlay", "$(src):$(dst)"])
-    end
-
     # Add in entrypoint, if it is set
     if config.entrypoint !== nothing
         append!(cmd_string, ["--entrypoint", config.entrypoint])

--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -162,7 +162,6 @@ function build_executor_command(exe::UserNamespacesExecutor, config::SandboxConf
 
     # Add in overlay mappings
     for (dst, src) in config.overlay_maps
-        config.persist || error("Cannot use overlay mappings without persistence enabled")
         append!(cmd_string, ["--overlay", "$(src):$(dst)"])
     end
 

--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -160,6 +160,12 @@ function build_executor_command(exe::UserNamespacesExecutor, config::SandboxConf
         append!(cmd_string, ["--workspace", "$(src):$(dst)"])
     end
 
+    # Add in overlay mappings
+    for (dst, src) in config.overlay_maps
+        config.persist || error("Cannot use overlay mappings without persistence enabled")
+        append!(cmd_string, ["--overlay", "$(src):$(dst)"])
+    end
+
     # Add in entrypoint, if it is set
     if config.entrypoint !== nothing
         append!(cmd_string, ["--entrypoint", config.entrypoint])

--- a/test/Sandbox.jl
+++ b/test/Sandbox.jl
@@ -193,6 +193,10 @@ for executor in all_executors
                     @test !isfile(joinpath(read_only_dir, "science"))
                     @test isfile(joinpath(overlay_dir, "upper", "science"))
                 end
+
+                # JuliaLang/julia#47650: overlayfs' restrictive permissions cause problems
+                Sandbox.chmod_recursive(joinpath(overlay_dir, "work", "work"), 0o700,
+                                        executor <: PrivilegedUserNamespacesExecutor)
             end
         end
 

--- a/test/Sandbox.jl
+++ b/test/Sandbox.jl
@@ -178,7 +178,7 @@ for executor in all_executors
                     overlay_maps = Dict("/read_only" => overlay_dir),
                     stdout = stdout,
                     stderr = stderr,
-                    persist = true,
+                    persist = false,
                 )
                 with_executor(executor) do exe
                     # a read-only map becomes read-write if we've overlaid it
@@ -191,7 +191,7 @@ for executor in all_executors
 
                     # make sure there were no changes to the underlying read-only map
                     @test !isfile(joinpath(read_only_dir, "science"))
-                    @test isfile(joinpath(overlay_dir, "science"))
+                    @test isfile(joinpath(overlay_dir, "upper", "science"))
                 end
             end
         end

--- a/test/Sandbox.jl
+++ b/test/Sandbox.jl
@@ -17,6 +17,8 @@ function print_if_nonempty(stderr::Vector{UInt8})
     return true
 end
 
+@testset "Sandboxing" begin
+
 rootfs_dir = Sandbox.debian_rootfs()
 for executor in all_executors
     if !executor_available(executor)
@@ -24,7 +26,7 @@ for executor in all_executors
         continue
     end
 
-    @testset "$(executor) Sandboxing" begin
+    @testset "$(executor)" begin
         @testset "capturing stdout/stderr" begin
             stdout = IOBuffer()
             stderr = IOBuffer()
@@ -351,4 +353,7 @@ end
         @test String(take!(stdout)) == "stdout\n";
         @test String(take!(stderr)) == "stderr\n";
     end
+end
+
+
 end


### PR DESCRIPTION
Adds overlay maps to the usernamespace sandbox so that we can create overlay mounts (e.g. to make read-only mounts mutable) in a controlled manner (i.e. without having to peek into the executor's `persistence_dir`):

```julia
using Sandbox

overlay = mktempdir()
config = SandboxConfig(
    Dict("/" => Sandbox.debian_rootfs(),
         "/root/.julia/packages" => "/home/tim/.julia/packages");
    overlay_maps = Dict("/root/.julia/packages" => overlay),
    stdin, stdout, stderr, persist=false, verbose=true,
)

with_executor(UnprivilegedUserNamespacesExecutor) do exe
    run(exe, config, ignorestatus(`/bin/bash -c "touch /root/.julia/packages/foo"`))
end

# $overlay/upper/foo now exists
```

```
verbose sandbox enabled (running in unprivileged container mode)
Parsed --rootfs as "/home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f"
Parsed --cd as "/"
Parsed --map as "/home/tim/.julia/packages" -> "/root/.julia/packages"
Parsed --overlay as "/tmp/jl_XwYhld" -> "/root/.julia/packages"
Parsed --uid as "0"
Parsed --gid as "0"
Child Process PID is 1712994
--> Mapping 1000:1000 to 0:0 within container namespace
--> Creating overlay workdir at /root
--> Mounting overlay of /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f at /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f (modifications in /root/upper/rootfs, workspace in /root/work/rootfs)
--> Bind-mounting /home/tim/.julia/packages over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f/root/.julia/packages (read-only)
--> Mounting procfs at /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f/proc
--> Bind-mounting /dev/null over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f//dev/null (read-write)
--> Bind-mounting /dev/tty over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f//dev/tty (read-write)
--> Bind-mounting /dev/zero over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f//dev/zero (read-write)
--> Bind-mounting /dev/random over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f//dev/random (read-write)
--> Bind-mounting /dev/urandom over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f//dev/urandom (read-write)
--> Bind-mounting /dev/shm over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f//dev/shm (read-write)
--> Bind-mounting /sys over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f//sys (read-only)
--> Bind-mounting /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f/dev/pts/ptmx over /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f/dev/ptmx (read-write)
--> Mounting overlay of /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f/root/.julia/packages at /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f/root/.julia/packages (modifications in /tmp/jl_XwYhld/upper, workspace in /tmp/jl_XwYhld/work)
Entering rootfs at /home/tim/Julia/depot/artifacts/4d66e139e0bcfdfa5ec6a8942a938e754e17860f
--> pivot_root() succeeded and unmounted old root
About to run `/bin/bash` `-c` `touch /root/.julia/packages/foo`
Child Process 1712994 exited with code 0
```

Intended use case: PkgEval, where we need a way to mount the package store. That mount needs to be read-only, since concurrent access results in corruption, yet we need a way to catch changes and add them to the cache afterwards. We cannot use layered depots for this because compilecache files hard-code the path to the Julia sources (see https://github.com/JuliaCI/PkgEval.jl/issues/158).

It would be cleaner if the overlay dir passed to the container would only be used as the upper dir, so that we can directly use the files in there, and not have to worry about removing the `work` directory (which has bad permissions that trigger a Julia bug, and may even be root-owned in the case of the PrivilegedUserNamespaceExecutor), but sadly the workdir has to live on the same filesystem as the upper dir.