### PR TITLE
Add a couple of precompilation statements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sandbox"
 uuid = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"

--- a/src/Sandbox.jl
+++ b/src/Sandbox.jl
@@ -274,4 +274,11 @@ end
 # The multiarch rootfs is truly multiarch
 multiarch_rootfs(;platform=nothing) = artifact"multiarch-rootfs"
 
+# Precompilation section
+let
+    f(exe) = run(exe, SandboxConfig(Dict("/" => "/")), `/bin/bash -c exit`)
+    precompile(select_executor, (Bool,))
+    precompile(with_executor, (typeof(f),))
+end
+
 end # module


### PR DESCRIPTION
`main` (da1ccc1017fac4a2a42de98c30a29e337fb06e74):
```console
% julia +1.7 --startup-file=no --project=/tmp -q
julia> using Sandbox; @time @eval Sandbox.select_executor(false);
  2.771236 seconds (10.20 M allocations: 540.632 MiB, 7.27% gc time, 100.00% compilation time)

% julia +1.8 --startup-file=no --project=/tmp -q
julia> using Sandbox; @time @eval Sandbox.select_executor(false);
  2.598736 seconds (8.77 M allocations: 448.371 MiB, 7.11% gc time, 99.77% compilation time)

% julia +1.9 --startup-file=no --project=/tmp -q
julia> using Sandbox; @time @eval Sandbox.select_executor(false);
  2.492451 seconds (4.97 M allocations: 332.907 MiB, 6.76% gc time, 99.71% compilation time)
```

This PR:
```console
% julia +1.7 --startup-file=no --project=/tmp -q
julia> using Sandbox; @time @eval Sandbox.select_executor(false);
  0.046847 seconds (1.96 k allocations: 120.734 KiB, 100.02% compilation time)

% julia +1.8 --startup-file=no --project=/tmp -q
julia> using Sandbox; @time @eval Sandbox.select_executor(false);
  1.136760 seconds (45.95 k allocations: 2.163 MiB, 99.34% compilation time)

% julia +1.9 --startup-file=no --project=/tmp -q
julia> using Sandbox; @time @eval Sandbox.select_executor(false);
  0.007143 seconds (8.53 k allocations: 526.817 KiB)
```

This makes this package much more useful for quick usage.  Fix #76 (except with v1.8, but it's still faster than without any precompilation statements).