### PR TITLE
forward all commonly user-generated signals

### DIFF
--- a/deps/userns_common.c
+++ b/deps/userns_common.c
@@ -125,12 +125,17 @@ void signal_passthrough(int sig) {
 // The list of signals that we will forward to our child process
 int forwarded_signals[] = {
   SIGHUP,
-  SIGPIPE,
-  SIGSTOP,
   SIGINT,
-  SIGTERM,
+  SIGQUIT,
   SIGUSR1,
   SIGUSR2,
+  SIGTERM,
+  SIGCONT,
+  SIGSTOP,
+  SIGTSTP,
+  SIGTTIN,
+  SIGTTOU,
+  SIGWINCH
 };
 
 void setup_signal_forwarding() {


### PR DESCRIPTION
Notably, adding SIGQUIT, but also the TTY signals (in case we ended up as a tty owner), and sorting the list by signal number