### PR TITLE
Handle missing AppArmor sysctls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Sandbox"
 uuid = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "2.1.3"
+version = "2.1.4"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"

--- a/src/UserNamespaces.jl
+++ b/src/UserNamespaces.jl
@@ -259,6 +259,43 @@ function build_executor_command(exe::UserNamespacesExecutor, config::SandboxConf
 end
 
 _userns_sysctl_props = ("apparmor_restrict_unprivileged_userns", "apparmor_restrict_unprivileged_unconfined")
+function _userns_sysctl_path(prop; proc_sys::AbstractString="/proc/sys")
+    return joinpath(proc_sys, "kernel", replace(prop, "." => "/"))
+end
+
+function _userns_sysctl_exists(prop; proc_sys::AbstractString="/proc/sys")
+    return isfile(_userns_sysctl_path(prop; proc_sys))
+end
+
+function _read_userns_sysctl(prop; proc_sys::AbstractString="/proc/sys")
+    if !_userns_sysctl_exists(prop; proc_sys)
+        return nothing
+    end
+
+    try
+        return readchomp(_userns_sysctl_path(prop; proc_sys))
+    catch e
+        if isa(e, Base.IOError)
+            return nothing
+        end
+        rethrow(e)
+    end
+end
+
+function _available_userns_sysctl_props(; sysctl_exists::Function=_userns_sysctl_exists)
+    return String[prop for prop in _userns_sysctl_props if sysctl_exists(prop)]
+end
+
+function _restricted_userns_sysctl_props(; read_sysctl::Function=_read_userns_sysctl)
+    failed_props = String[]
+    for prop in _userns_sysctl_props
+        if read_sysctl(prop) == "1"
+            push!(failed_props, prop)
+        end
+    end
+    return failed_props
+end
+
 function check_restricted_unprivileged_userns()
     if !Sys.islinux()
         return
@@ -275,33 +312,42 @@ function check_restricted_unprivileged_userns()
     # And so, I regret more and more every day that I don't just give up and reimplement
     # everything on top of podman.  Until then, just ask the user to turn off these
     # annoying protections:
-    if Sys.which("sysctl") !== nothing
-        failed_props = String[]
-        for prop in _userns_sysctl_props
-            if readchomp(`sysctl kernel.$(prop)`) == "kernel.$(prop) = 1"
-                push!(failed_props, prop)
-            end
-        end
-        if !isempty(failed_props)
-            @error("""
-            You have likely run into an issue due to over-zealous apparmor protections:
-            https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
+    failed_props = _restricted_userns_sysctl_props()
+    if !isempty(failed_props)
+        @error("""
+        You have likely run into an issue due to over-zealous apparmor protections:
+        https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
 
-            To disable these protections, run: `Sandbox.disable_apparmor_userns_restrictions()`
-            This will require your sudo password.
-            """)
-        end
+        To disable these protections, run: `Sandbox.disable_apparmor_userns_restrictions()`
+        This will require your sudo password.
+        """)
     end
 end
 
 function disable_apparmor_userns_restrictions()
+    if !Sys.islinux()
+        @info("AppArmor user namespace restrictions are Linux-specific; nothing to disable.")
+        return nothing
+    end
+
+    available_props = _available_userns_sysctl_props()
+    if isempty(available_props)
+        @info("No AppArmor user namespace restriction sysctls found; nothing to disable.")
+        return nothing
+    end
+
+    missing_props = setdiff(collect(_userns_sysctl_props), available_props)
+    if !isempty(missing_props)
+        @info("Skipping absent AppArmor user namespace restriction sysctls", missing_props)
+    end
+
     sysctl_commands = IOBuffer()
-    for prop in _userns_sysctl_props
+    for prop in available_props
         println(sysctl_commands, "kernel.$(prop) = 0")
     end
     seekstart(sysctl_commands)
     run(pipeline(`sudo tee /etc/sysctl.d/99-sandbox-unprivileged-user-namespaces.conf`, stdin=sysctl_commands, stdout=devnull))
-    for prop in _userns_sysctl_props
+    for prop in available_props
         run(`sudo sysctl -w kernel.$(prop)=0`)
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -298,27 +298,49 @@ function default_persist_root_dirs()
     return dirs
 end
 
-function find_persist_dir_root(rootfs_path::String, dir_hints::Vector{String} = default_persist_root_dirs(); verbose::Bool = false)
-    function probe_overlay_mount(rootfs_path, mount_path; verbose::Bool = false, userxattr::Bool = false)
-        probe_exe = UserNSSandbox_jll.overlay_probe_path
-        probe_args = String[]
-        if verbose
-            push!(probe_args, "--verbose")
-        end
-        if userxattr
-            push!(probe_args, "--userxattr")
-        end
-
-        # Guard against `realpath()` issues below
-        if !isdir(rootfs_path) || !isdir(mount_path)
-            return false
-        end
-
-        return success(run(pipeline(ignorestatus(
-            `$(probe_exe) $(probe_args) $(realpath(rootfs_path)) $(realpath(mount_path))`
-        ); stdout = verbose ? stdout : devnull, stderr = verbose ? stderr : devnull)))
+function _probe_overlay_mount(rootfs_path::String, mount_path::String;
+                              verbose::Bool = false, userxattr::Bool = false,
+                              probe_exe = UserNSSandbox_jll.overlay_probe_path)
+    probe_args = String[]
+    if verbose
+        push!(probe_args, "--verbose")
+    end
+    if userxattr
+        push!(probe_args, "--userxattr")
     end
 
+    # Guard against `realpath()` issues below
+    if !isdir(rootfs_path) || !isdir(mount_path)
+        return false
+    end
+
+    probe_parent_dir = nothing
+    try
+        # userns_overlay_probe creates fixed paths below its parent directory.
+        # Give each probe attempt a private parent on the candidate filesystem so
+        # concurrent Julia processes do not collide while probing the same root.
+        probe_parent_dir = mktempdir(mount_path)
+        return success(run(pipeline(ignorestatus(
+            `$(probe_exe) $(probe_args) $(realpath(rootfs_path)) $(realpath(probe_parent_dir))`
+        ); stdout = verbose ? stdout : devnull, stderr = verbose ? stderr : devnull)))
+    catch e
+        if isa(e, Base.IOError)
+            return false
+        end
+        rethrow(e)
+    finally
+        if probe_parent_dir !== nothing
+            try
+                rm(probe_parent_dir; force=true, recursive=true)
+            catch e
+                @debug "Unable to clean up overlay probe directory" probe_parent_dir exception=(e, catch_backtrace())
+            end
+        end
+    end
+end
+
+function find_persist_dir_root(rootfs_path::String, dir_hints::Vector{String} = default_persist_root_dirs();
+                               verbose::Bool = false, probe_overlay_mount::Function = _probe_overlay_mount)
     # If one of our `dir_hints` works, use that, as those are typically our first
     # choices; things like a scratchspace, a user-supplied path, etc...
     for mount_path in dir_hints, userxattr in (true, false)

--- a/test/Nesting.jl
+++ b/test/Nesting.jl
@@ -144,7 +144,7 @@ end
                         with_executor(executor; privileges) do exe
                             @test !success(exe, config_with_stderr, cmd)
                             # Ensure that we get the nested sandbox unable to run any nested sandboxing
-                            @test_broken occursin("Could not find any available executors", String(take!(stderr)))
+                            @test occursin("Could not find any available executors", String(take!(stderr)))
                         end
                     end
                 end

--- a/test/UserNamespaces.jl
+++ b/test/UserNamespaces.jl
@@ -5,6 +5,37 @@ if Sys.islinux()
     @test Sandbox.check_kernel_version()
 end
 
+@testset "AppArmor userns sysctl helpers" begin
+    props = Sandbox._userns_sysctl_props
+
+    mktempdir() do proc_sys
+        @test Sandbox._read_userns_sysctl(props[1]; proc_sys) === nothing
+        @test isempty(Sandbox._available_userns_sysctl_props(;
+            sysctl_exists = prop -> Sandbox._userns_sysctl_exists(prop; proc_sys),
+        ))
+
+        sysctl_path = Sandbox._userns_sysctl_path(props[1]; proc_sys)
+        mkpath(dirname(sysctl_path))
+        write(sysctl_path, "1\n")
+
+        @test Sandbox._userns_sysctl_exists(props[1]; proc_sys)
+        @test Sandbox._read_userns_sysctl(props[1]; proc_sys) == "1"
+        @test Sandbox._available_userns_sysctl_props(;
+            sysctl_exists = prop -> Sandbox._userns_sysctl_exists(prop; proc_sys),
+        ) == [props[1]]
+    end
+
+    values = Dict(props[1] => "1", props[2] => nothing)
+    @test Sandbox._restricted_userns_sysctl_props(; read_sysctl = prop -> get(values, prop, nothing)) == [props[1]]
+
+    values[props[1]] = "0"
+    values[props[2]] = "1"
+    @test Sandbox._restricted_userns_sysctl_props(; read_sysctl = prop -> get(values, prop, nothing)) == [props[2]]
+
+    empty!(values)
+    @test isempty(Sandbox._restricted_userns_sysctl_props(; read_sysctl = prop -> get(values, prop, nothing)))
+end
+
 @testset "chmod_recursive with dangling/inaccessible symlinks" begin
     mktempdir() do dir
         # Create a directory tree similar to an overlay upper dir

--- a/test/UserNamespaces.jl
+++ b/test/UserNamespaces.jl
@@ -36,6 +36,79 @@ end
     @test isempty(Sandbox._restricted_userns_sysctl_props(; read_sysctl = prop -> get(values, prop, nothing)))
 end
 
+if Sys.islinux()
+    @testset "concurrent persistence probes use unique work dirs" begin
+        mktempdir() do dir
+            rootfs = joinpath(dir, "rootfs")
+            candidate = joinpath(dir, "candidate")
+            probe_log = joinpath(dir, "probe.log")
+            probe_exe = joinpath(dir, "fake-overlay-probe")
+            mkpath(rootfs)
+            mkpath(candidate)
+            touch(probe_log)
+
+            write(probe_exe, """
+            #!/bin/sh
+            set -eu
+
+            while [ "\$#" -gt 0 ]; do
+                case "\$1" in
+                    --verbose|--userxattr|--tmpfs)
+                        shift
+                        ;;
+                    --uid|--gid)
+                        shift 2
+                        ;;
+                    --*)
+                        exit 2
+                        ;;
+                    *)
+                        break
+                        ;;
+                esac
+            done
+
+            rootfs="\$1"
+            probe_parent="\$2"
+            [ -d "\$rootfs" ]
+            [ -d "\$probe_parent" ]
+
+            marker="\$probe_parent/in-use"
+            mkdir "\$marker"
+            printf '%s\\n' "\$probe_parent" >> "$(probe_log)"
+            sleep 0.2
+            rmdir "\$marker"
+            """)
+            chmod(probe_exe, 0o755)
+
+            function probe_overlay_mount(rootfs_path, mount_path; verbose=false, userxattr=false)
+                return Sandbox._probe_overlay_mount(rootfs_path, mount_path; verbose, userxattr, probe_exe=probe_exe)
+            end
+
+            nprobes = 8
+            results = Vector{Any}(undef, nprobes)
+            @sync for idx in eachindex(results)
+                @async begin
+                    results[idx] = Sandbox.find_persist_dir_root(
+                        rootfs,
+                        [candidate];
+                        probe_overlay_mount,
+                    )
+                end
+            end
+
+            @test all(==((candidate, true)), results)
+
+            probe_parents = split(chomp(read(probe_log, String)), '\n')
+            @test length(probe_parents) == nprobes
+            @test length(unique(probe_parents)) == nprobes
+            @test all(parent -> dirname(parent) == realpath(candidate), probe_parents)
+            @test all(parent -> !ispath(parent), probe_parents)
+            @test isempty(readdir(candidate))
+        end
+    end
+end
+
 @testset "chmod_recursive with dangling/inaccessible symlinks" begin
     mktempdir() do dir
         # Create a directory tree similar to an overlay upper dir


### PR DESCRIPTION
The AppArmor user namespace sysctls only exist on kernels with Ubuntu's newer restriction enabled. Treat absent keys as not applicable so the diagnostic path does not mask the original sandbox failure, and make the disabling helper skip sysctls that are not present.

Fixes an issue seen on Julia CI (`Process(`sysctl kernel.apparmor_restrict_unprivileged_userns`, ProcessExited(255))` surfacing) after unprivileged probing failed.